### PR TITLE
Possible fix for #29 - Update regex of FRU for parsing not only digits

### DIFF
--- a/check_ipmi_sensor
+++ b/check_ipmi_sensor
@@ -1034,7 +1034,7 @@ MAIN: {
 		if( $use_fru ){
 			@server_serial = grep(/Product Serial Number/,@fruoutput);
 			if(@server_serial){
-				$server_serial[0] =~ m/(\d+)/;
+				$server_serial[0] =~ m/\:\s+(.*)$/;
 				$serial_number = $1;
 			}
 		}


### PR DESCRIPTION
This commit should fix it, as the regex now parses everything behind the columns. I don't have serials with columns, so please recheck this with valid hosts. Tests with my hosts and a regex test were ok.