### PR TITLE
Add --nodcmi option

### DIFF
--- a/check_ipmi_sensor
+++ b/check_ipmi_sensor
@@ -55,7 +55,7 @@ check_ipmi_sensor -H <hostname>
   [-i <sensor id>] [-o zenoss] [-D <protocol LAN version>] [-h] [-V]
   [-fc <num_fans>] [--fru] [--assettag] [--board] [--nosel] [--selonly] 
   [--seltail <count>] [-sx|--selexclude <sel exclude file>] 
-  [-xx|--sexclude <exclude file>] [-us|--unify-sensors <unify file>] [--nosudo [--nothresholds]
+  [-xx|--sexclude <exclude file>] [-us|--unify-sensors <unify file>] [--nosudo] [--nothresholds]
   [--noentityabsent] [-s <ipmi-sensor output file>] [-h] [-V]
   [-v|-vv|-vvv]
 EOT

--- a/check_ipmi_sensor
+++ b/check_ipmi_sensor
@@ -55,8 +55,9 @@ check_ipmi_sensor -H <hostname>
   [-i <sensor id>] [-o zenoss] [-D <protocol LAN version>] [-h] [-V]
   [-fc <num_fans>] [--fru] [--assettag] [--board] [--nosel] [--selonly] 
   [--seltail <count>] [-sx|--selexclude <sel exclude file>] 
-  [-xx|--sexclude <exclude file>] [-us|--unify-sensors <unify file>] [--nosudo] [--nothresholds]
-  [--noentityabsent] [-s <ipmi-sensor output file>] [-h] [-V]
+  [-xx|--sexclude <exclude file>] [-us|--unify-sensors <unify file>] [--nosudo]
+  [--nothresholds] [--nodcmi] [--noentityabsent]
+  [-s <ipmi-sensor output file>] [-h] [-V]
   [-v|-vv|-vvv]
 EOT
 }
@@ -207,6 +208,8 @@ sub get_help{
        turn off performance data thresholds from output-sensor-thresholds.
   [--noentityabsent]
        skip sensor checks for sensors that have 'noentityabsent' as event state
+  [--nodcmi]
+       turn off power statistics via ipmi-dcmi.
   [-s <ipmi-sensor output file>]
        simulation mode - test the plugin with an ipmi-sensor output redirected
        to a file.
@@ -575,7 +578,7 @@ MAIN: {
 	my @exclude_sel_sensor_types;
 	my $sel_issues_present = 0;
 	my $simulate = '';
-	my ($use_fru, $use_asset, $use_board, $no_sel, $sel_only, $sel_tail, $no_sudo, $use_thresholds, $no_thresholds, $sel_xfile, $s_xfile, $s_ufile, $no_entity_absent);
+	my ($use_fru, $use_asset, $use_board, $no_sel, $sel_only, $sel_tail, $no_sudo, $use_thresholds, $no_thresholds, $sel_xfile, $s_xfile, $s_ufile, $no_entity_absent, $no_dcmi);
 
 	#read in command line arguments and init hash variables with the given values from argv
 	if ( !( GetOptions(
@@ -599,6 +602,7 @@ MAIN: {
 		'seltail=s'			=> \$sel_tail,
 		'nosudo'			=> \$no_sudo,
 		'nothresholds'			=> \$no_thresholds,
+		'nodcmi'			=> \$no_dcmi,
 		'noentityabsent'	=> \$no_entity_absent,
 		'v|verbosity'		=> \$verbosity,
 		'vv'				=> sub{$verbosity=2},
@@ -812,7 +816,9 @@ MAIN: {
 		$seloutput = parse_sel(\@selcmd, $verbosity, $sel_xfile, \@sel_sensor_types, \@exclude_sel_sensor_types, \@sel_options);
 	}
 	my $dcmioutput;
-	$dcmioutput = parse_dcmi(\@dcmicmd, $verbosity);
+	if(!$no_dcmi){
+		$dcmioutput = parse_dcmi(\@dcmicmd, $verbosity);
+	}
 ################################################################################
 # print debug output when verbosity is set to 3 (-vvv)
 	if ( $verbosity == 3 && !$sel_only ){


### PR DESCRIPTION
This option turns off getting power statistics via ipmi-dcmi. This can be slow and increase the runtime of the check.
